### PR TITLE
Fetch git branch to be diffed before code review

### DIFF
--- a/src/api/git-api.ts
+++ b/src/api/git-api.ts
@@ -35,6 +35,13 @@ export async function checkoutLocalBranch(branchName: string) {
     await git.checkoutLocalBranch(branchName);
 }
 
+export async function fetchBranch(projectPath: string, branchName: string) {
+    logger.info(`Fetching branch ${branchName} from project ${projectPath}`);
+    await initGit();
+    await setRemoteIfNeeded(projectPath);
+    await git.fetch('origin', branchName);
+}
+
 export async function checkoutBranch(projectPath: string, branchName: string) {
     logger.info(`Checking out branch ${branchName} from project ${projectPath}`);
     await initGit();

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -10,6 +10,7 @@ import {
     addAllToGit,
     checkForChanges,
     checkoutBranch,
+    fetchBranch,
     checkoutLocalBranch,
     commitGitChanges, initGit,
     pushGitChanges
@@ -124,6 +125,10 @@ export async function execute(context: GitLabExecutionContext) {
 
         // checkout another branch if needed:
         const branchToPull = taskExtractionResult.checkoutBranch;
+        const targetBranch = taskExtractionResult.targetBranch;
+        if (targetBranch && targetBranch !== branchToPull) {
+            await fetchBranch(projectPath, targetBranch);
+        }
         await checkoutBranch(projectPath, branchToPull);
 
         const junieTask = await taskExtractionResult.generateJuniePrompt(context.useMcp);

--- a/src/models/task-extraction-result.ts
+++ b/src/models/task-extraction-result.ts
@@ -40,6 +40,7 @@ export interface JunieTask {
 export interface SuccessfulTaskExtractionResult {
     success: true;
     checkoutBranch: string;
+    targetBranch?: string;
 
     generateJuniePrompt(useMcp: boolean): Promise<JunieTask>;
 
@@ -61,6 +62,10 @@ export class IssueCommentTask implements SuccessfulTaskExtractionResult {
         public readonly fetchedData: FetchedData,
         public readonly checkoutBranch: string,
     ) {
+    }
+
+    get targetBranch(): string {
+        return this.checkoutBranch;
     }
 
     async generateJuniePrompt(useMcp: boolean): Promise<JunieTask> {
@@ -129,6 +134,10 @@ export class MergeRequestCommentTask implements SuccessfulTaskExtractionResult {
 
     get checkoutBranch(): string {
         return this.context.mergeRequestSourceBranch;
+    }
+
+    get targetBranch(): string {
+        return this.context.mergeRequestTargetBranch;
     }
 
     async generateJuniePrompt(useMcp: boolean): Promise<JunieTask> {
@@ -213,6 +222,10 @@ export class MergeRequestEventTask implements SuccessfulTaskExtractionResult {
 
     get checkoutBranch(): string {
         return this.context.mrEventSourceBranch;
+    }
+
+    get targetBranch(): string {
+        return this.context.mrEventTargetBranch;
     }
 
     async generateJuniePrompt(useMcp: boolean): Promise<JunieTask> {


### PR DESCRIPTION
Hi,
at the moment we have issues where the code-review doesn't work. After analyzing it a bit I've come to the conclusion that the branch to diff against was not fetched correctly. This patch fixes that for us and code-review works again.

For transparency: The patch was created using Junie and reviewed by me.